### PR TITLE
programmers: 42746

### DIFF
--- a/programmers.com/learn/courses/30/lessons/42746.test.ts
+++ b/programmers.com/learn/courses/30/lessons/42746.test.ts
@@ -1,0 +1,13 @@
+import solution from './42746'
+
+describe('[6, 10, 2] will return', () => {
+  test('6210', () => {
+    expect(solution([6, 10, 2])).toEqual('6210')
+  })
+})
+
+describe('[3, 30, 34, 5, 9] will return', () => {
+  test('9534330', () => {
+    expect(solution([3, 30, 34, 5, 9])).toEqual('9534330')
+  })
+})

--- a/programmers.com/learn/courses/30/lessons/42746.ts
+++ b/programmers.com/learn/courses/30/lessons/42746.ts
@@ -1,0 +1,7 @@
+export default function solution(numbers: number[]) {
+  return numbers.reduce((a, b) => a + b) === 0
+    ? '0'
+    : numbers.sort(compare).join('')
+}
+
+const compare = (a: number, b: number) => (a + '' + b > b + '' + a ? -1 : 1)


### PR DESCRIPTION
# 가장 큰 수

> 문제 타입 : 정렬

## 문제

0 또는 양의 정수가 주어졌을 때, 정수를 이어 붙여 만들 수 있는 가장 큰 수를 알아내 주세요.

예를 들어, 주어진 정수가 [6, 10, 2]라면 [6102, 6210, 1062, 1026, 2610, 2106]를 만들 수 있고, 이중 가장 큰 수는 6210입니다.

0 또는 양의 정수가 담긴 배열 numbers가 매개변수로 주어질 때, 순서를 재배치하여 만들 수 있는 가장 큰 수를 문자열로 바꾸어 return 하도록 solution 함수를 작성해주세요.

### 제한 사항

- numbers의 길이는 1 이상 100,000 이하입니다.
- numbers의 원소는 0 이상 1,000 이하입니다.
- 정답이 너무 클 수 있으니 문자열로 바꾸어 return 합니다.

### 입출력 예

| numbers           | return  |
| ----------------- | ------- |
| [6, 10, 2]        | 6210    |
| [3, 30, 34, 5, 9] | 9534330 |

---

## 해설

수 A, 그 뒤의 수 B를 ‘AB' ‘BA’ 로 합쳐 비교해서 내림차순으로 정렬하면 된다.

원소가 0인 반례의 경우 0을 출력하게 처리하면 끝이다.