### PR TITLE
BOJ: 11726-7

### DIFF
--- a/acmicpc.net/problem/11726.py
+++ b/acmicpc.net/problem/11726.py
@@ -1,0 +1,20 @@
+def solution(n):
+    d = [None]*(n+1)
+    d[0] = 1
+    d[1] = 1
+
+    for i in range(2, n+1):
+        d[i] = d[i-1] + d[i-2]
+        d[i] %= 10007
+
+    return d[n]
+
+
+def test_solution():
+    assert solution(2) == 2
+    assert solution(9) == 55
+
+
+if __name__ == "__main__":
+    n = int(input())
+    print(solution(n))

--- a/acmicpc.net/problem/11727.py
+++ b/acmicpc.net/problem/11727.py
@@ -1,0 +1,21 @@
+def solution(n):
+    d = [None]*(n+1)
+    d[0] = 1
+    d[1] = 1
+
+    for i in range(2, n+1):
+        d[i] = d[i-1] + (d[i-2] * 2)
+        d[i] %= 10007
+
+    return d[n]
+
+
+def test_solution():
+    assert solution(2) == 3
+    assert solution(8) == 171
+    assert solution(12) == 2731
+
+
+if __name__ == "__main__":
+    n = int(input())
+    print(solution(n))


### PR DESCRIPTION
# 2 x n 타일링

2×n 크기의 직사각형을 1×2, 2×1 타일로 채우는 방법의 수를 구하는 프로그램을 작성하시오.

아래 그림은 2×5 크기의 직사각형을 채운 한 가지 방법의 예이다.

<img src="https://user-images.githubusercontent.com/5278201/79457814-c7aa5780-802b-11ea-9d6e-2d57c25f82a2.png" width="250px" alt="tile" />

## 입력

첫째 줄에 n이 주어진다. (1 ≤ n ≤ 1,000)

## 출력

첫째 줄에 2×n 크기의 직사각형을 채우는 방법의 수를 10,007로 나눈 나머지를 출력한다.

## 예시

| n    | 출력 |
| ---- | ---- |
| 2    | 2    |
| 9    | 55   |

---

# 풀이

D<sub>i</sub>를 2xi 크기의 직사각형을 1×2, 2×1 타일로 채우는 방법의 수라고 정의한다.

점화식은 D<sub>i</sub> = D<sub>i-1</sub> + D<sub>i-2</sub> (D<sub>i-1</sub>는 1x2 타일이고, D<sub>i-2</sub>는 2x1타일이다.)

기저는 D<sub>1, 2</sub> = 1 이다.

두번째 문제는 2 x n 타일링에서 2x2 타일이 추가 된 문제로, 

2x1타일이 오는 경우를 다시 한번 더하면 2x2 타일이 추가된 결과를 얻을 수 있다.